### PR TITLE
fix: install deps as user instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,12 @@ RUN chmod 554 run.sh && \
 COPY --chown=$USER:$USER pyproject.toml ./
 COPY --chown=$USER:$USER uv.lock* ./
 
-RUN pip install uv && \
-    uv sync
+RUN pip install uv
 
 USER $USER
+
+RUN uv sync --no-dev
+
+ENV PATH="/home/$USER/.venv/bin:$PATH"
 
 ENTRYPOINT ["sh", "run.sh"]

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,0 +1,42 @@
+# Local Docker Testing Guide
+
+## Building the Image
+
+```bash
+# Build the Docker image
+docker build -t docker-s3backup:latest .
+```
+
+## Running the Container Locally
+
+### Running with Interactive Shell (for debugging)
+
+```bash
+docker run -it --rm --entrypoint sh docker-s3backup:latest
+```
+
+## Environment Variables
+
+- `ACCESS_KEY`: AWS IAM Access Key
+- `SECRET_KEY`: AWS IAM Secret Key
+- `S3PATH`: S3 bucket and path (e.g., `s3://my-bucket/backups`)
+- `CRON_SCHEDULE`: Cron schedule (default: `0 3 * * 6` - Saturdays at 3 AM)
+- `LOG_LEVEL`: Logging level (default: `INFO`)
+
+## Volume Mounts
+
+- `/backup`: Directory to backup (mount as read-only `:ro`)
+- `/config`: Directory for cache and log files (write access needed)
+
+## Useful Docker Commands
+
+```bash
+# List built images
+docker images | grep docker-s3backup
+
+# View container logs
+docker logs <container_id>
+
+# Clean up
+docker image rm docker-s3backup:latest
+```


### PR DESCRIPTION
When swiching to UV, deps were installed as root instead of the `s3backup` user.